### PR TITLE
Update daypicker currentmonth

### DIFF
--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -143,7 +143,7 @@ export default class DateRangePicker extends React.Component {
 
     const endDate = toMomentObject(endDateString, this.getDisplayFormat());
 
-    const isEndDateValid = endDate && !isOutsideRange(endDapte) &&
+    const isEndDateValid = endDate && !isOutsideRange(endDate) &&
       !isInclusivelyBeforeDay(endDate, startDate);
     if (isEndDateValid) {
       onDatesChange({ startDate, endDate });

--- a/src/components/DateRangePicker.jsx
+++ b/src/components/DateRangePicker.jsx
@@ -22,13 +22,14 @@ import DayPicker from './DayPicker';
 import CloseButton from '../svg/close.svg';
 
 import DateRangePickerShape from '../shapes/DateRangePickerShape';
-
 import {
   START_DATE,
   END_DATE,
   HORIZONTAL_ORIENTATION,
   VERTICAL_ORIENTATION,
 } from '../../constants';
+
+moment.locale('ko');
 
 const propTypes = DateRangePickerShape;
 
@@ -142,7 +143,7 @@ export default class DateRangePicker extends React.Component {
 
     const endDate = toMomentObject(endDateString, this.getDisplayFormat());
 
-    const isEndDateValid = endDate && !isOutsideRange(endDate) &&
+    const isEndDateValid = endDate && !isOutsideRange(endDapte) &&
       !isInclusivelyBeforeDay(endDate, startDate);
     if (isEndDateValid) {
       onDatesChange({ startDate, endDate });
@@ -329,6 +330,7 @@ export default class DateRangePicker extends React.Component {
       onPrevMonthClick,
       onNextMonthClick,
       withPortal,
+      focusedInput,
       withFullScreenPortal,
       enableOutsideDays,
     } = this.props;
@@ -362,6 +364,10 @@ export default class DateRangePicker extends React.Component {
           orientation={orientation}
           enableOutsideDays={enableOutsideDays}
           modifiers={modifiers}
+          isStartDateFocused={focusedInput === START_DATE}
+          isEndDateFocused={focusedInput === END_DATE}
+          startDate={this.props.startDate || moment()}
+          endDate={this.props.endDate || moment()}
           numberOfMonths={numberOfMonths}
           onDayMouseEnter={this.onDayMouseEnter}
           onDayMouseLeave={this.onDayMouseLeave}

--- a/src/components/DayPicker.jsx
+++ b/src/components/DayPicker.jsx
@@ -18,6 +18,8 @@ import OrientationShape from '../shapes/OrientationShape';
 
 import { HORIZONTAL_ORIENTATION, VERTICAL_ORIENTATION } from '../../constants';
 
+import momentPropTypes from 'react-moment-proptypes';
+
 const CALENDAR_MONTH_WIDTH = 300;
 const DAY_PICKER_PADDING = 9;
 const MONTH_PADDING = 23;
@@ -44,6 +46,10 @@ const propTypes = {
 
   // i18n
   monthFormat: PropTypes.string,
+  isStartDateFocused: PropTypes.bool,
+  isEndDateFocused: PropTypes.bool,
+  startDate: momentPropTypes.momentObj,
+  endDate: momentPropTypes.momentObj
 };
 
 const defaultProps = {
@@ -99,6 +105,22 @@ export default class DayPicker extends React.Component {
         this.adjustDayPickerHeight();
       }
     }
+  }
+
+  componentWillReceiveProps(nextProps) {
+    let currentMonth = moment();
+
+    if (nextProps.isStartDateFocused) {
+      currentMonth = nextProps.startDate;
+    }
+
+    if (nextProps.isEndDateFocused) {
+      currentMonth = nextProps.endDate;
+    }
+
+    this.setState({
+        currentMonth
+    });
   }
 
   getMonthHeightByIndex(i) {

--- a/src/shapes/DateRangePickerShape.js
+++ b/src/shapes/DateRangePickerShape.js
@@ -8,7 +8,7 @@ export default {
   startDate: momentPropTypes.momentObj,
   endDate: momentPropTypes.momentObj,
   focusedInput: FocusedInputShape,
-  minimumNights: PropTypes.number,
+  minimumNights: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   isDayBlocked: PropTypes.func,
   isOutsideRange: PropTypes.func,
   enableOutsideDays: PropTypes.bool,


### PR DESCRIPTION
1. day picker 의 componentWillReceiveProps 에서 currentMonth 값을 현재 선택된 input에 맞춰서 변경해주도록 수정

2. 1의 내용을 위해 daterangepicker에서 isStartDateFocused, isEndDateFocused, startDate, endDate 값 props으로 전달

3. daterangepicker의 minimumNights 타입이 string으로 넘어올때가 있어서 oneOfType으로 변경